### PR TITLE
Fix notice : "undefined index" in register.php

### DIFF
--- a/register.php
+++ b/register.php
@@ -27,7 +27,7 @@
             }
 
             function isErrorPresent($errorNumber) {
-              if ($_SESSION["errorForm"] !== NULL){
+              if (isset($_SESSION["errorForm"])) {
                 for ($i = 0; $i < count($_SESSION["errorForm"]); $i++) {
                   foreach ($_SESSION["errorForm"] as $key) {
                     if ($errorNumber === $key) {


### PR DESCRIPTION
Fix issue: display notice "undefined index error form"
I have replaced the condition `($_SESSION["errorForm"] !== NULL)` by  `($_SESSION["errorForm"] !== NULL)`.

Tested. It works fine.