### PR TITLE
Fix invisible update message in admin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -119,7 +119,7 @@ function successfulUpdateMessage() {
 function alertSuccessMessage($message){
   echo '<div class="push"></div>';
 
-  echo '<div class="alert alert-success alert-dismissible fade show" role="alert">' . $message .
+  echo '<div class="alert alert-success alert-dismissible show" role="alert">' . $message .
       '<button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span></button></div>';
 }


### PR DESCRIPTION
The `fade` class get an `opaque: 0` CSS property (=transparent)

See https://github.com/Stephanyan/soundbase/blob/1b9cf1ecb2c1653bf662b9b6b678943113c9ee28/vendor/bootstrap/css/bootstrap.css#L3101

Fixes https://github.com/Stephanyan/soundbase/issues/37